### PR TITLE
Add function to send a single bit (true | false) over the Sigfox network

### DIFF
--- a/examples/SendBoolean/SendBoolean.ino
+++ b/examples/SendBoolean/SendBoolean.ino
@@ -1,0 +1,29 @@
+#include <SigFox.h>
+#define VALUE_TO_SEND 1
+#define DEBUG 1
+void setup() {
+
+  if (DEBUG){
+    Serial.begin(9600);
+    while (!Serial) {};
+  }
+
+  if (!SigFox.begin()) {
+    if (DEBUG){
+      Serial.println("Sigfox module unavailable !");
+    }
+    return;
+  }
+  if (DEBUG){
+    SigFox.debug();
+    Serial.println("ID  = " + SigFox.ID());
+  }
+  delay(100);
+  int ret = SigFox.sendBit(VALUE_TO_SEND);
+  if (DEBUG){
+    Serial.print("Status : ");
+    Serial.println(ret);
+  }
+}
+
+void loop(){}

--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Arduino LLC
 sentence=Helper library for MKRFox1200 board and ATAB8520E Sigfox module
 paragraph=This library allows some high level operations on Sigfox module, to ease integration with existing projects
 category=Device Control
-url=http://arduino.cc/libraries/Sigfox
+url=https://www.arduino.cc/en/Reference/SigFox
 architectures=samd

--- a/src/SigFox.h
+++ b/src/SigFox.h
@@ -82,6 +82,12 @@ class SIGFOXClass : public Stream
   template <typename T> inline size_t write(T val) {return write((uint8_t*)&val, sizeof(T));};
   using Print::write;
 
+  /*
+  * Send a single bit (0 | 1) over the Sigfox network
+  * Returns the status code from the Atmel Sigfox chipset
+  **/
+  int sendBit(bool value);
+
   //makes no sense in Sigfox world
   void flush() {};
 


### PR DESCRIPTION
This uses a different SPI transaction (`0x0B`), and allows to send empty frames for basic applications such as buttons, door opening systems, ...
Added a simple example called _SendBoolean_

@facchinm  : Let me know if I need to structure this differently to fit with the lib architecture :)

+ Fix link to arduino.cc in the library properties (related to #1 )