### PR TITLE
Remove magic values for LowPower.sleep()

### DIFF
--- a/src/SigFox.h
+++ b/src/SigFox.h
@@ -98,6 +98,7 @@ class SIGFOXClass : public Stream
   * Read status (fill ssm,atm,sig status variables)
   */
   void status();
+  void status_without_delay();
   /*
   * Return status code.
   * Type: 0 -> ssm status ; 1 -> atm status ; 2 -> sigfox status    


### PR DESCRIPTION
As of now, the SigFox library uses kind of magic values when it comes to LowPower.sleep usage, as can be seen [here](https://github.com/arduino-libraries/SigFox/blob/master/src/SigFox.cpp#L163) and [here](https://github.com/arduino-libraries/SigFox/blob/master/src/SigFox.cpp#L230). After reading the datasheet from Atmel, [here](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-9409-Smart-RF-ATA8520E_Datasheet.pdf), point 2.2.3 seems to give a hint, where they are coming from, it's still bad to rely on hardcoded sleep times.

This PR removes time based sleep entirely, and waits for the interrupt coming from the `SIGFOX_EVENT_PIN` only. After some testing, this definitely lead to more accurate return values of SigFox.endPacket.

Anyway, this does only work with a fixed version of the Low Power library, see https://github.com/arduino-libraries/ArduinoLowPower/pull/9.
As of now, it is not possible to register interrupts for the SigFox event pin.

Btw this [commit](https://github.com/arduino-libraries/RTCZero/commit/d4bd4ec4fd4e8907f3f5785b843d71800b57f4f6) fixed the problems with the controllers being unable to wake up from LowPower.sleep at all. Using RTCZero including this commit, removes the need to always run with the debugging mode turned on.