### PR TITLE
Be more gentle with SPI in Low Power mode

### DIFF
--- a/src/SigFox.cpp
+++ b/src/SigFox.cpp
@@ -167,8 +167,12 @@ int SIGFOXClass::send(unsigned char mess[], int len, bool rx)
 
   if (!debugging) {
 #ifdef SIGFOX_SPI
+    spi_port->end();
     LowPower.attachInterruptWakeup(interrupt_pin, NULL, FALLING);
     LowPower.sleep(timeout);
+    spi_port->begin();
+    spi_port->setDataMode(SPI_MODE0);
+    spi_port->setBitOrder(MSBFIRST);
 #endif
     if (digitalRead(interrupt_pin) == 0) {
       status();
@@ -231,8 +235,12 @@ int SIGFOXClass::sendBit(bool value){
 
   if (!debugging) {
 #ifdef SIGFOX_SPI
+    spi_port->end();
     LowPower.attachInterruptWakeup(interrupt_pin, NULL, FALLING);
     LowPower.sleep(timeout);
+    spi_port->begin();
+    spi_port->setDataMode(SPI_MODE0);
+    spi_port->setBitOrder(MSBFIRST);
 #endif
     if (digitalRead(interrupt_pin) == 0) {
       status();
@@ -643,6 +651,7 @@ void SIGFOXClass::end()
   delay(1);
   digitalWrite(chip_select_pin, HIGH);
   delay(1);
+  spi_port->end();
 }
 
 SIGFOXClass SigFox; //singleton


### PR DESCRIPTION
This is to fix issue #16 where SPI doesn't see to ecover properly when SPI is kept open while Low Power is invoked.