### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=This library allows some high level operations on Sigfox module, to ea
 category=Device Control
 url=https://www.arduino.cc/en/Reference/SigFox
 architectures=samd
+depends=Arduino Low Power

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Arduino SigFox for MKRFox1200
-version=1.0.4
+version=1.0.5
 author=Arduino
 maintainer=Arduino LLC
 sentence=Helper library for MKRFox1200 board and ATAB8520E Sigfox module


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes Library Manager to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format