### PR TITLE
Correct misspelling in example comment

### DIFF
--- a/examples/WeatherMonitorStream/WeatherMonitorStream.ino
+++ b/examples/WeatherMonitorStream/WeatherMonitorStream.ino
@@ -31,7 +31,7 @@
 #include <Adafruit_TSL2561_U.h>
 #include "conversions.h"
 
-// Set oneshot to false to trigger continuous mode when you finisched setting up the whole flow
+// Set oneshot to false to trigger continuous mode when you finished setting up the whole flow
 int oneshot = true;
 
 Adafruit_BMP280  bmp;


### PR DESCRIPTION
A dictionary update in [the codespell spell checker tool](https://github.com/codespell-project/codespell) caught this typo, resulting in a the CI workflow [failing](https://github.com/arduino-libraries/SigFox/actions/runs/1025766236).