### PR TITLE
Correct issue report creation link in Contribution Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines
 
-This library is the culmination of the expertise of many members of the open source community who have dedicated their time and hard work. The best way to ask for help or propose a new idea is to [create a new issue](https://github.com/arduino/SigFox/issues/new), while creating a Pull Request with your code changes allows you to share your own innovations with the rest of the community.
+This library is the culmination of the expertise of many members of the open source community who have dedicated their time and hard work. The best way to ask for help or propose a new idea is to [create a new issue](https://github.com/arduino-libraries/SigFox/issues/new), while creating a Pull Request with your code changes allows you to share your own innovations with the rest of the community.
 
 The following are some guidelines to observe when creating issues or PRs:
 


### PR DESCRIPTION
The link URL previously used the `arduino` organization rather than the `arduino-libraries` organization the repository is hosted under.

Supersedes https://github.com/arduino-libraries/SigFox/pull/21 (which can't be merged due to CLA not having been signed).