### PR TITLE
Correct case of "Type" in librarymanager links in examples

### DIFF
--- a/examples/WeatherMonitor/WeatherMonitor.ino
+++ b/examples/WeatherMonitor/WeatherMonitor.ino
@@ -9,10 +9,10 @@
     TSL2561 Light Sensor to get luminosity
 
   Download the needed libraries from the following links
-  http://librarymanager/all#BMP280&Adafruit
-  http://librarymanager/all#HTU21D&Adafruit
-  http://librarymanager/all#TSL2561&Adafruit
-  http://librarymanager/all#adafruit&sensor&abstraction
+  http://librarymanager/All#BMP280&Adafruit
+  http://librarymanager/All#HTU21D&Adafruit
+  http://librarymanager/All#TSL2561&Adafruit
+  http://librarymanager/All#adafruit&sensor&abstraction
 
   Since the Sigfox network can send a maximum of 120 messages per day (depending on your plan)
   we'll optimize the readings and send data in compact binary format

--- a/examples/WeatherMonitorStream/WeatherMonitorStream.ino
+++ b/examples/WeatherMonitorStream/WeatherMonitorStream.ino
@@ -9,10 +9,10 @@
     TSL2561 Light Sensor to get luminosity
 
   Download the needed libraries from the following links
-  http://librarymanager/all#BMP280&Adafruit
-  http://librarymanager/all#HTU21D&Adafruit
-  http://librarymanager/all#TSL2561&Adafruit
-  http://librarymanager/all#adafruit&sensor&abstraction
+  http://librarymanager/All#BMP280&Adafruit
+  http://librarymanager/All#HTU21D&Adafruit
+  http://librarymanager/All#TSL2561&Adafruit
+  http://librarymanager/All#adafruit&sensor&abstraction
 
   Since the Sigfox network can send a maximum of 120 messages per day (depending on your plan)
   we'll optimize the readings and send data in compact binary format


### PR DESCRIPTION
Arduino IDE has a feature where opening a link of the form:

```
http://librarymanager[/<type>[/<topic>]][#<search keywords>]
```

opens Library Manager with the specified filters and keywords prefilled.

Support for specifying the "Type" filter setting was claimed during the implementation of the feature in Arduino IDE 1.x (https://github.com/arduino/Arduino/commit/b99ab40ba29cdc45d0ff239295b351ebd990b65c), but that never actually worked. The text in this path was simply ignored by the IDE (a fact that would not be obvious from the links used by this library, since the "All" type filter setting is the default anyway).

During the reimplementation of the feature in Arduino IDE 2.x (https://github.com/arduino/arduino-ide/pull/1481), support for specifying the "Type" filter setting was actually implemented correctly. Instead of ignoring this path component of the URL, the IDE requires it to match to a valid "Type" filter value. If there is no match, opening the link has no effect. This match is case sensitive.

The previous URLs used the type value "all", but there is no "all" value in the "Type" filter. Instead, there is an "All" value, and that exact case must be used in order for the link to function in Arduino IDE 2.x.