### PR TITLE
Change maintainer to `Arduino <info@arduino.cc>`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Arduino SigFox for MKRFox1200
 version=1.0.5
 author=Arduino
-maintainer=Arduino LLC
+maintainer=Arduino <info@arduino.cc>
 sentence=Helper library for MKR Fox 1200 board and ATAB8520E Sigfox module
 paragraph=This library allows some high level operations on Sigfox modules, to ease integration with existing projects
 category=Device Control


### PR DESCRIPTION
Maintainer is changed from `Arduino LLC` to `Arduino <info@arduino.cc>` within the `library.properties` file. 